### PR TITLE
Fix translator key type check

### DIFF
--- a/translator/translator.go
+++ b/translator/translator.go
@@ -81,7 +81,16 @@ func parseLanguageId(conf Config) (locales.Translator, []locales.Translator, err
 }
 
 func (ut *translator) Translate(ctx context.Context, key interface{}, params ...string) (string, error) {
-	if key == nil || key.(string) == "" {
+	if key == nil {
+		return "", nil
+	}
+
+	strKey, ok := key.(string)
+	if !ok {
+		return "", errors.NewWithCode(codes.CodeTranslatorError, "key must be a string")
+	}
+
+	if strKey == "" {
 		return "", nil
 	}
 
@@ -91,6 +100,6 @@ func (ut *translator) Translate(ctx context.Context, key interface{}, params ...
 		trans = ut.translator.GetFallback()
 	}
 
-	return trans.T(key, params...)
+	return trans.T(strKey, params...)
 
 }


### PR DESCRIPTION
## Summary
- ensure `Translate` handles non-string keys safely

## Testing
- `go vet ./...` *(fails: forbidden module download)*
- `make run-tests` *(fails: forbidden module download)*

------
https://chatgpt.com/codex/tasks/task_b_686dea1ec3648328b9516c3d834014b2