### PR TITLE
Rename Base64SaltSeparator field

### DIFF
--- a/security/security.go
+++ b/security/security.go
@@ -40,7 +40,7 @@ type security struct {
 
 type ScryptConfig struct {
 	Base64SignerKey     string
-	Base64SaltSeperator string
+	Base64SaltSeparator string
 	Rounds              int
 	MemoryCost          int
 }
@@ -165,7 +165,7 @@ func (s *security) ScryptPassword(ctx context.Context, salt string, password str
 	N := 1 << s.scrypt.MemoryCost // CPU/memory cost parameter (must be a power of 2)
 	r := s.scrypt.Rounds          // block size parameter
 	p := 1                        // parallelization parameter
-	saltConcat := append(s.b64Stddecode(ctx, salt), s.b64Stddecode(ctx, s.scrypt.Base64SaltSeperator)...)
+	saltConcat := append(s.b64Stddecode(ctx, salt), s.b64Stddecode(ctx, s.scrypt.Base64SaltSeparator)...)
 	derivedKey, err := scrypt.Key([]byte(password), saltConcat, N, r, p, keyLen)
 	if err != nil {
 		s.log.Error(ctx, fmt.Sprintf("Error generating derived key: %v", err))

--- a/security/security_test.go
+++ b/security/security_test.go
@@ -170,7 +170,7 @@ func Test_security_CompareHashPassword(t *testing.T) {
 func Test_security_ScryptPassword(t *testing.T) {
 	config := ScryptConfig{
 		Base64SignerKey:     "MoaHZJjRSE9Ktj6HnIkoldV+BmXpD7YVboHgJOY4SDnUNiNMTUILxlsY4igO3Uzx/n/VwFju9IC4fQfgDy7LwQ==",
-		Base64SaltSeperator: "Bw==",
+		Base64SaltSeparator: "Bw==",
 		Rounds:              8,
 		MemoryCost:          14,
 	}
@@ -219,7 +219,7 @@ func Test_security_ScryptPassword(t *testing.T) {
 func Test_security_CompareScryptPassword(t *testing.T) {
 	config := ScryptConfig{
 		Base64SignerKey:     "MoaHZJjRSE9Ktj6HnIkoldV+BmXpD7YVboHgJOY4SDnUNiNMTUILxlsY4igO3Uzx/n/VwFju9IC4fQfgDy7LwQ==",
-		Base64SaltSeperator: "Bw==",
+		Base64SaltSeparator: "Bw==",
 		Rounds:              8,
 		MemoryCost:          14,
 	}


### PR DESCRIPTION
## Summary
- rename `Base64SaltSeperator` field to `Base64SaltSeparator`
- update references and tests

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_686deb572e5c83289e21df9b9336ff99