### PR TITLE
Patch v1.0.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,6 +44,11 @@ jobs:
           exit 1
         fi
 
+    - name: Check go mod tidy
+      run: |
+        go mod tidy
+        git diff --exit-code go.mod go.sum
+
     - name: Run tests
       run: make run-tests
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,22 @@ on:
           - "major"
 
 jobs:
+  validate:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Build
+        run: make build
+      - name: Run tests
+        run: make run-tests
+
   release:
+    needs: validate
     timeout-minutes: 30
     runs-on: ubuntu-latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,11 +8,9 @@ linters:
     - gosec
     - misspell
   disable:
-    - errcheck
     - asasalint
     - asciicheck
     - bidichk
-    - bodyclose
     - containedctx
     - contextcheck
     - cyclop

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,19 @@ build:
 
 .PHONY: run-tests
 run-tests:
-	@go test -v -failfast `go list ./...` -cover
+	@go test -v `go list ./...` -cover
 
 .PHONY: run-tests-report
 run-tests-report:
-	@go test -v -failfast `go list ./...` -cover -coverprofile=coverage.out -json > test-report.out
+	@go test -v `go list ./...` -cover -coverprofile=coverage.out -json > test-report.out
 
 .PHONY: run-integ-tests
 run-integ-tests:
-	@go test -v -failfast `go list ./...` -cover -tags=integration
+	@go test -v `go list ./...` -cover -tags=integration
 
 .PHONY: run-integ-tests-report
 run-integ-tests-report:
-	@go test -v -failfast `go list ./...` -cover  -tags=integration -coverprofile=coverage.out -json > test-report.out
+	@go test -v `go list ./...` -cover  -tags=integration -coverprofile=coverage.out -json > test-report.out
 
 .PHONY: lint
 lint:

--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -1,3 +1,6 @@
+// Package appcontext defines typed accessors and setters for
+// request-scoped values (request id, user agent, IP, body, headers,
+// timings) carried through a context.Context.
 package appcontext
 
 import (

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -1,3 +1,6 @@
+// Package audit emits structured audit records (HTTP captures and
+// domain-level Record events) as zerolog log lines, enriched from the
+// surrounding appcontext and the resolved user identity.
 package audit
 
 import (

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -3,15 +3,12 @@ package audit
 import (
 	"context"
 	"os"
-	"sync"
 
 	"github.com/downsized-devs/sdk-go/appcontext"
 	"github.com/downsized-devs/sdk-go/auth"
 	"github.com/downsized-devs/sdk-go/operator"
 	"github.com/rs/zerolog"
 )
-
-var once = sync.Once{}
 
 type Interface interface {
 	Capture(ctx context.Context)
@@ -24,15 +21,12 @@ type audit struct {
 }
 
 func Init(auth auth.Interface) Interface {
-	var zeroLogging zerolog.Logger
-
-	// Initialize a new Zerolog object to handle the split log file
-	once.Do(func() {
-		zeroLogging = zerolog.New(os.Stdout).
-			With().
-			Timestamp().
-			Logger()
-	})
+	// A fresh logger is built on every Init call so that successive
+	// Inits don't share zero-value state with the first one.
+	zeroLogging := zerolog.New(os.Stdout).
+		With().
+		Timestamp().
+		Logger()
 
 	return &audit{log: zeroLogging, auth: auth}
 }

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -54,6 +54,30 @@ func Test_audit_Capture(t *testing.T) {
 	}
 }
 
+// Test_audit_Init_MultipleCalls regresses the pre-1.0.1 sync.Once bug where
+// the second (and later) Init calls returned an audit with a zero-value
+// zerolog.Logger because the once.Do body had already run.
+func Test_audit_Init_MultipleCalls(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	authMock := mock_auth.NewMockInterface(ctrl)
+	authMock.EXPECT().GetUserAuthInfo(gomock.Any()).Return(auth.UserAuthInfo{}, nil).AnyTimes()
+
+	first := Init(authMock)
+	second := Init(authMock)
+
+	ctx := appcontext.SetEventName(context.Background(), "tests")
+	// If the logger were zero-value, Capture would still not panic on
+	// zerolog (it writes to a nil writer fine), so additionally assert
+	// that the two audit values are independent allocations.
+	first.Capture(ctx)
+	second.Capture(ctx)
+
+	if first == second {
+		t.Fatalf("expected Init to return independent values; got the same pointer twice")
+	}
+}
+
 func Test_audit_Record(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/auth/README.md
+++ b/auth/README.md
@@ -35,7 +35,7 @@ import (
 )
 
 log := logger.Init(logger.Config{Level: "info"})
-json := parser.InitParser(log, parser.Options{}).JSONParser()
+json := parser.Init(log, parser.Options{}).JSONParser()
 
 a := auth.Init(auth.Config{
     Firebase: auth.FirebaseConf{
@@ -44,7 +44,7 @@ a := auth.Init(auth.Config{
     },
 }, log, json, http.DefaultClient)
 
-tok, err := a.VerifyToken(context.Background(), "Bearer eyJhbGciOi...")
+tok, err := a.VerifyToken(context.Background(), "<ID_TOKEN>")
 ```
 
 ## API Reference
@@ -95,7 +95,9 @@ func AuthMiddleware(a auth.Interface) gin.HandlerFunc {
             c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
             return
         }
-        ctx := a.SetUserAuthInfo(c.Request.Context(), auth.UserAuthParam{UID: tok.UID})
+        ctx := a.SetUserAuthInfo(c.Request.Context(), auth.UserAuthParam{
+            FirebaseToken: tok,
+        })
         c.Request = c.Request.WithContext(ctx)
         c.Next()
     }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -227,7 +227,7 @@ func (a *auth) RegisterUser(ctx context.Context, user FirebaseUser) (FirebaseUse
 	}
 
 	if user.IsDisabled.Valid {
-		params.Disabled(user.IsEmailVerified.Bool)
+		params.Disabled(user.IsDisabled.Bool)
 	}
 
 	u, err := a.firebase.CreateUser(ctx, params)
@@ -276,7 +276,7 @@ func (a *auth) UpdateUser(ctx context.Context, user FirebaseUser) (FirebaseUser,
 	}
 
 	if user.IsDisabled.Valid {
-		params.Disabled(user.IsEmailVerified.Bool)
+		params.Disabled(user.IsDisabled.Bool)
 	}
 
 	if user.Password != "" {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,3 +1,8 @@
+// Package auth wraps the Firebase Admin SDK to provide ID-token
+// verification, password sign-in, refresh-token exchange, and user
+// CRUD. It exposes an Interface that callers can mock for tests and a
+// SetUserAuthInfo/GetUserAuthInfo pair for propagating authenticated
+// principals through context.
 package auth
 
 import (
@@ -27,6 +32,8 @@ const (
 	userAuthInfo contextKey = "UserAuthInfo"
 )
 
+// Interface is the public surface of the auth package. Callers depend
+// on this interface so they can swap in a mock for tests.
 type Interface interface {
 	VerifyToken(ctx context.Context, bearertoken string) (*firebase_auth.Token, error)
 	GetUser(ctx context.Context, userParam FirebaseUserParam) ([]FirebaseUser, error)
@@ -63,16 +70,23 @@ type auth struct {
 	conf              Config
 }
 
+// Config controls how Init builds the auth client. SkipFirebaseInit is
+// intended for tests or environments where the upstream Firebase
+// connection should be skipped entirely; the returned Interface still
+// satisfies the contract but all live operations return CodeNotImplemented.
 type Config struct {
 	SkipFirebaseInit bool
 	Firebase         FirebaseConf
 }
 
+// FirebaseConf groups the Firebase-specific credentials.
 type FirebaseConf struct {
 	AccountKey FirebaseAccountKey
 	ApiKey     string
 }
 
+// FirebaseAccountKey mirrors the JSON shape of a Firebase service-account
+// credentials file.
 type FirebaseAccountKey struct {
 	Type                    string `json:"type"`
 	ProjectID               string `json:"project_id"`
@@ -86,6 +100,10 @@ type FirebaseAccountKey struct {
 	Clientx509CertURL       string `json:"client_x509_cert_url"`
 }
 
+// Init constructs an auth client from cfg. It calls log.Fatal on
+// non-recoverable initialization failures (bad credentials, network
+// errors during Firebase bootstrap). Pass cfg.SkipFirebaseInit=true to
+// short-circuit the live Firebase connection — useful for tests.
 func Init(cfg Config, log logger.Interface, json parser.JsonInterface, httpClient *http.Client) Interface {
 	if cfg.SkipFirebaseInit {
 		return &auth{

--- a/auth/auth_extra_test.go
+++ b/auth/auth_extra_test.go
@@ -3,8 +3,10 @@ package auth
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
+	"unsafe"
 
 	firebase_auth "firebase.google.com/go/auth"
 	mock_logger "github.com/downsized-devs/sdk-go/tests/mock/logger"
@@ -20,12 +22,14 @@ type fakeFirebaseAuth struct {
 	getUsersErr error
 	getUsersIds []firebase_auth.UserIdentifier
 
-	createRes *firebase_auth.UserRecord
-	createErr error
+	createRes    *firebase_auth.UserRecord
+	createErr    error
+	createParams *firebase_auth.UserToCreate
 
-	updateRes *firebase_auth.UserRecord
-	updateErr error
-	updateUID string
+	updateRes    *firebase_auth.UserRecord
+	updateErr    error
+	updateUID    string
+	updateParams *firebase_auth.UserToUpdate
 
 	deleteErr error
 	deleteUID string
@@ -43,12 +47,14 @@ func (f *fakeFirebaseAuth) GetUsers(_ context.Context, identifiers []firebase_au
 	return f.getUsersRes, f.getUsersErr
 }
 
-func (f *fakeFirebaseAuth) CreateUser(_ context.Context, _ *firebase_auth.UserToCreate) (*firebase_auth.UserRecord, error) {
+func (f *fakeFirebaseAuth) CreateUser(_ context.Context, p *firebase_auth.UserToCreate) (*firebase_auth.UserRecord, error) {
+	f.createParams = p
 	return f.createRes, f.createErr
 }
 
-func (f *fakeFirebaseAuth) UpdateUser(_ context.Context, uid string, _ *firebase_auth.UserToUpdate) (*firebase_auth.UserRecord, error) {
+func (f *fakeFirebaseAuth) UpdateUser(_ context.Context, uid string, p *firebase_auth.UserToUpdate) (*firebase_auth.UserRecord, error) {
 	f.updateUID = uid
+	f.updateParams = p
 	return f.updateRes, f.updateErr
 }
 
@@ -179,6 +185,36 @@ func TestRegisterUser_Success(t *testing.T) {
 	assert.Equal(t, "uid-new", got.ID)
 }
 
+func TestRegisterUser_ForwardsIsDisabled(t *testing.T) {
+	cases := []struct {
+		name     string
+		disabled bool
+	}{
+		{"disabled=true", true},
+		{"disabled=false", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeFirebaseAuth{createRes: sampleUserRecord("uid", "x@y")}
+			a := newAuthWithFake(t, fake)
+
+			in := FirebaseUser{Email: "x@y", Password: "pw", DisplayName: "X"}
+			// Email verified flipped opposite to ensure the wrong field isn't forwarded.
+			in.IsEmailVerified.Valid = true
+			in.IsEmailVerified.Bool = !tc.disabled
+			in.IsDisabled.Valid = true
+			in.IsDisabled.Bool = tc.disabled
+
+			_, err := a.RegisterUser(context.Background(), in)
+			require.NoError(t, err)
+
+			got, ok := userToCreateParams(fake.createParams)["disabled"].(bool)
+			require.True(t, ok, "disabled param should be set as a bool")
+			assert.Equal(t, tc.disabled, got)
+		})
+	}
+}
+
 func TestRegisterUser_Error(t *testing.T) {
 	fake := &fakeFirebaseAuth{createErr: errors.New("create failed")}
 	a := newAuthWithFake(t, fake)
@@ -204,6 +240,35 @@ func TestUpdateUser_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "uid-1", got.ID)
 	assert.Equal(t, "uid-1", fake.updateUID)
+}
+
+func TestUpdateUser_ForwardsIsDisabled(t *testing.T) {
+	cases := []struct {
+		name     string
+		disabled bool
+	}{
+		{"disabled=true", true},
+		{"disabled=false", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeFirebaseAuth{updateRes: sampleUserRecord("uid-1", "x@y")}
+			a := newAuthWithFake(t, fake)
+
+			in := FirebaseUser{ID: "uid-1", Email: "x@y"}
+			in.IsEmailVerified.Valid = true
+			in.IsEmailVerified.Bool = !tc.disabled
+			in.IsDisabled.Valid = true
+			in.IsDisabled.Bool = tc.disabled
+
+			_, err := a.UpdateUser(context.Background(), in)
+			require.NoError(t, err)
+
+			got, ok := userToUpdateParams(fake.updateParams)["disableUser"].(bool)
+			require.True(t, ok, "disableUser param should be set as a bool")
+			assert.Equal(t, tc.disabled, got)
+		})
+	}
 }
 
 func TestUpdateUser_Error(t *testing.T) {
@@ -293,6 +358,27 @@ func sampleUserRecord(uid, email string) *firebase_auth.UserRecord {
 			LastLogInTimestamp: 2_000,
 		},
 	}
+}
+
+// userToCreateParams reads the unexported params map from a firebase
+// UserToCreate so tests can assert which fields were forwarded.
+func userToCreateParams(u *firebase_auth.UserToCreate) map[string]interface{} {
+	return readParamsField(u)
+}
+
+// userToUpdateParams reads the unexported params map from a firebase
+// UserToUpdate so tests can assert which fields were forwarded.
+func userToUpdateParams(u *firebase_auth.UserToUpdate) map[string]interface{} {
+	return readParamsField(u)
+}
+
+func readParamsField(v any) map[string]interface{} {
+	rv := reflect.ValueOf(v).Elem().FieldByName("params")
+	rv = reflect.NewAt(rv.Type(), unsafe.Pointer(rv.UnsafeAddr())).Elem()
+	if rv.IsNil() {
+		return nil
+	}
+	return rv.Interface().(map[string]interface{})
 }
 
 // authWithLoggerCapture builds an auth with a real-enough logger mock that

--- a/auth/auth_http.go
+++ b/auth/auth_http.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -37,14 +36,17 @@ func (a *auth) exchangeRefreshToken(ctx context.Context, payLoad RefreshTokenReq
 	if err != nil {
 		return result, errors.NewWithCode(codes.CodeErrorHttpDo, "%s", err.Error())
 	}
+	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return result, errors.NewWithCode(codes.CodeErrorIoutilReadAll, "%s", err.Error())
 	}
 
-	if resp.StatusCode != 200 {
-		a.log.Error(ctx, fmt.Sprintf("error exchange refresh token, req: %v, resp: %s", payLoad, string(body)))
+	if resp.StatusCode != http.StatusOK {
+		// Do not log the refresh-token payload or the upstream response body;
+		// both can carry secrets. Only the status code is safe to record.
+		a.log.Error(ctx, errors.NewWithCode(codes.CodeErrorHttpDo, "error exchange refresh token, status=%d", resp.StatusCode))
 		return result, errors.NewWithCode(codes.CodeErrorHttpDo, "error exchangeRefreshToken")
 	}
 

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -2,9 +2,11 @@ package checker
 
 import "regexp"
 
-const (
-	phoneRegex = `^[0][8]\d{8,14}$`
-	emailRegex = `^[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,4}$`
+// phoneRegex and emailRegex are compiled once at package init so that
+// IsPhoneNumber and IsEmail do not pay the regex-compile cost on every call.
+var (
+	phoneRegex = regexp.MustCompile(`^[0][8]\d{8,14}$`)
+	emailRegex = regexp.MustCompile(`^[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,4}$`)
 )
 
 type AllowedDataType interface {
@@ -45,11 +47,9 @@ func ArrayDeduplicate[T AllowedDataType](values []T) []T {
 }
 
 func IsPhoneNumber(phone string) bool {
-	phoneRegex := regexp.MustCompile(phoneRegex)
 	return phoneRegex.MatchString(phone)
 }
 
 func IsEmail(email string) bool {
-	emailRegex := regexp.MustCompile(emailRegex)
 	return emailRegex.MatchString(email)
 }

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -1,3 +1,6 @@
+// Package checker provides small validation predicates (phone, email)
+// and generic slice helpers (Contains, Deduplicate) used throughout the
+// SDK.
 package checker
 
 import "regexp"

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,3 +1,5 @@
+// Package clock exposes a tiny seam over time.Now and time.Since so
+// callers can inject deterministic clocks in tests.
 package clock
 
 import (

--- a/configreader/configreader.go
+++ b/configreader/configreader.go
@@ -59,7 +59,9 @@ func Init(opt Options) Interface {
 			panic(fmt.Errorf("fatal error found during reading additional config file. err: %w", err))
 		}
 		if addConf.ConfigKey == "" {
-			vp.MergeConfigMap(vpAddConf.AllSettings())
+			if err := vp.MergeConfigMap(vpAddConf.AllSettings()); err != nil {
+				panic(fmt.Errorf("fatal error merging additional config %s: %w", addConf.ConfigFile, err))
+			}
 		} else {
 			vp.Set(strings.ToLower(addConf.ConfigKey), vpAddConf.AllSettings())
 		}

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -1,3 +1,6 @@
+// Package convert offers type-coercion helpers (To/Int64, ToArrInt64,
+// ToFloat64, etc.) backed by reflection and the go-conv library. All
+// helpers return wrapped errors with CodeInvalidValue on failure.
 package convert
 
 import (

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -19,6 +19,9 @@ func ToInt64(i interface{}) (int64, error) {
 }
 
 func ToArrInt64(i interface{}) ([]int64, error) {
+	if i == nil {
+		return nil, errors.NewWithCode(codes.CodeInvalidValue, "input is nil")
+	}
 	val := make([]int64, 0)
 	// if the input is not a slice, convert the input to slice with one member
 	if reflect.TypeOf(i).Kind() != reflect.Slice {

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -48,6 +48,14 @@ func TestToArrInt64(t *testing.T) {
 			want:    []int64{1, 2, 3},
 			wantErr: false,
 		},
+		{
+			// Prior to v1.0.1 this branch panicked because reflect.TypeOf(nil)
+			// returns a nil Type and .Kind() would dereference it.
+			name:    "nil input returns error without panic",
+			args:    args{i: nil},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dates/dates.go
+++ b/dates/dates.go
@@ -1,3 +1,5 @@
+// Package dates collects small date/time helpers (differences,
+// formatting) that the rest of the SDK and consumers reuse.
 package dates
 
 import "time"

--- a/files/files.go
+++ b/files/files.go
@@ -22,7 +22,10 @@ func GetExtension(filename string) string {
 // Checks if a file exists and is not a directory
 func IsExist(filename string) bool {
 	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
+	if err != nil {
+		// Treat any stat error (not-found, permission denied, etc.) as
+		// "not a known regular file" so the caller never has to handle a
+		// nil FileInfo dereference here.
 		return false
 	}
 

--- a/files/files.go
+++ b/files/files.go
@@ -1,3 +1,5 @@
+// Package files contains small file-system helpers: extension parsing
+// and existence checks that never panic on permission errors.
 package files
 
 import (

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -70,6 +70,15 @@ func TestIsExist(t *testing.T) {
 			args: args{filename: "test_folder"},
 			want: false,
 		},
+		{
+			// Stat errors that are not "not found" (e.g. permission denied
+			// inside an unreadable directory) used to dereference a nil
+			// FileInfo. The fix swaps in a generic err != nil check; this
+			// case asserts the function returns false instead of panicking.
+			name: "stat error path returns false",
+			args: args{filename: "test_folder/no-such-dir/no-such-file"},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,8 @@ require (
 	modernc.org/sqlite v1.48.1
 )
 
+require github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
+
 require (
 	cloud.google.com/go/auth v0.14.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
@@ -72,7 +74,6 @@ require (
 	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
-	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
@@ -131,7 +132,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect

--- a/gqlclient/client.go
+++ b/gqlclient/client.go
@@ -39,7 +39,50 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"strings"
 )
+
+// maxLoggedBodyBytes caps how much of a variables payload or response body
+// is written to the debug log. Bodies above this size are truncated and an
+// explicit "(truncated)" suffix is appended so operators know the log line
+// is incomplete.
+const maxLoggedBodyBytes = 512
+
+// sensitiveHeaders is the case-insensitive set of headers whose values are
+// replaced with a fixed placeholder before being logged. Anything matching
+// here is assumed to carry credentials or session state.
+var sensitiveHeaders = map[string]struct{}{
+	"authorization": {},
+	"cookie":        {},
+	"x-api-key":     {},
+}
+
+// redactHeaders returns a shallow copy of h with the values of any
+// sensitive header replaced by "[REDACTED]". The original header map is
+// not mutated so the outgoing request is unaffected.
+func redactHeaders(h http.Header) http.Header {
+	if h == nil {
+		return nil
+	}
+	redacted := make(http.Header, len(h))
+	for k, v := range h {
+		if _, ok := sensitiveHeaders[strings.ToLower(k)]; ok {
+			redacted[k] = []string{"[REDACTED]"}
+			continue
+		}
+		redacted[k] = append([]string(nil), v...)
+	}
+	return redacted
+}
+
+// truncateForLog returns s capped at maxLoggedBodyBytes bytes with a
+// trailing "(truncated)" marker when the input is larger.
+func truncateForLog(s string) string {
+	if len(s) <= maxLoggedBodyBytes {
+		return s
+	}
+	return s[:maxLoggedBodyBytes] + "(truncated)"
+}
 
 type Interface interface {
 	Run(ctx context.Context, req *Request, resp interface{}) error
@@ -111,7 +154,7 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	if err := json.NewEncoder(&requestBody).Encode(requestBodyObj); err != nil {
 		return fmt.Errorf("encode body: %w", err)
 	}
-	c.logf(">> variables: %v", req.vars)
+	c.logf(">> variables: %s", truncateForLog(fmt.Sprintf("%v", req.vars)))
 	c.logf(">> query: %s", req.q)
 	gr := &graphResponse{
 		Data: resp,
@@ -128,7 +171,7 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 			r.Header.Add(key, value)
 		}
 	}
-	c.logf(">> headers: %v", r.Header)
+	c.logf(">> headers: %v", redactHeaders(r.Header))
 	r = r.WithContext(ctx)
 	res, err := c.httpClient.Do(r)
 	if err != nil {
@@ -139,7 +182,7 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	if _, err := io.Copy(&buf, res.Body); err != nil {
 		return fmt.Errorf("reading body: %w", err)
 	}
-	c.logf("<< %s", buf.String())
+	c.logf("<< %s", truncateForLog(buf.String()))
 	if err := json.NewDecoder(&buf).Decode(&gr); err != nil {
 		if res.StatusCode != http.StatusOK {
 			return fmt.Errorf("graphql: server returned a non-200 status code: %v", res.StatusCode)
@@ -181,7 +224,7 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	if err := writer.Close(); err != nil {
 		return fmt.Errorf("close writer: %w", err)
 	}
-	c.logf(">> variables: %s", variablesBuf.String())
+	c.logf(">> variables: %s", truncateForLog(variablesBuf.String()))
 	c.logf(">> files: %d", len(req.files))
 	c.logf(">> query: %s", req.q)
 	gr := &graphResponse{
@@ -199,7 +242,7 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 			r.Header.Add(key, value)
 		}
 	}
-	c.logf(">> headers: %v", r.Header)
+	c.logf(">> headers: %v", redactHeaders(r.Header))
 	r = r.WithContext(ctx)
 	res, err := c.httpClient.Do(r)
 	if err != nil {
@@ -210,7 +253,7 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	if _, err := io.Copy(&buf, res.Body); err != nil {
 		return fmt.Errorf("reading body: %w", err)
 	}
-	c.logf("<< %s", buf.String())
+	c.logf("<< %s", truncateForLog(buf.String()))
 	if err := json.NewDecoder(&buf).Decode(&gr); err != nil {
 		if res.StatusCode != http.StatusOK {
 			return fmt.Errorf("graphql: server returned a non-200 status code: %v", res.StatusCode)

--- a/gqlclient/client_extra_test.go
+++ b/gqlclient/client_extra_test.go
@@ -179,6 +179,33 @@ func TestRun_JSON_EncodeBodyError(t *testing.T) {
 	assert.Contains(t, err.Error(), "encode body")
 }
 
+func TestRedactHeaders(t *testing.T) {
+	in := http.Header{
+		"Authorization": []string{"Bearer secret-token"},
+		"Cookie":        []string{"session=abc"},
+		"X-Api-Key":     []string{"key-value"},
+		"User-Agent":    []string{"unit-test"},
+	}
+	got := redactHeaders(in)
+
+	assert.Equal(t, []string{"[REDACTED]"}, got["Authorization"])
+	assert.Equal(t, []string{"[REDACTED]"}, got["Cookie"])
+	assert.Equal(t, []string{"[REDACTED]"}, got["X-Api-Key"])
+	assert.Equal(t, []string{"unit-test"}, got["User-Agent"])
+	// Original must not have been mutated.
+	assert.Equal(t, "Bearer secret-token", in.Get("Authorization"))
+}
+
+func TestTruncateForLog(t *testing.T) {
+	short := strings.Repeat("a", maxLoggedBodyBytes)
+	long := strings.Repeat("b", maxLoggedBodyBytes+50)
+
+	assert.Equal(t, short, truncateForLog(short))
+	got := truncateForLog(long)
+	assert.True(t, strings.HasSuffix(got, "(truncated)"))
+	assert.Equal(t, maxLoggedBodyBytes+len("(truncated)"), len(got))
+}
+
 // Triggers the multipart non-200 + bad JSON body path.
 func TestRun_Multipart_Non200WithBadBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/gqlclient/client_test.go
+++ b/gqlclient/client_test.go
@@ -21,7 +21,7 @@ func TestDoJSON(t *testing.T) {
 		b, err := io.ReadAll(r.Body)
 		is.NoErr(err)
 		is.Equal(string(b), `{"query":"query {}","variables":null}`+"\n")
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"data": {
 				"something": "yes"
 			}
@@ -51,7 +51,7 @@ func TestDoJSONServerError(t *testing.T) {
 		is.NoErr(err)
 		is.Equal(string(b), `{"query":"query {}","variables":null}`+"\n")
 		w.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(w, `Internal Server Error`)
+		_, _ = io.WriteString(w, `Internal Server Error`)
 	}))
 	defer srv.Close()
 
@@ -76,7 +76,7 @@ func TestDoJSONBadRequestErr(t *testing.T) {
 		is.NoErr(err)
 		is.Equal(string(b), `{"query":"query {}","variables":null}`+"\n")
 		w.WriteHeader(http.StatusBadRequest)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"errors": [{
 				"message": "miscellaneous message as to why the the request was bad"
 			}]
@@ -177,7 +177,7 @@ func TestWithClient(t *testing.T) {
 	client := NewClient("", WithHTTPClient(testClient), UseMultipartForm())
 
 	req := NewRequest(``)
-	client.Run(ctx, req, nil)
+	_ = client.Run(ctx, req, nil)
 
 	is.Equal(calls, 1) // calls
 }
@@ -190,7 +190,7 @@ func TestDoUseMultipartForm(t *testing.T) {
 		is.Equal(r.Method, http.MethodPost)
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"data": {
 				"something": "yes"
 			}
@@ -217,7 +217,7 @@ func TestImmediatelyCloseReqBody(t *testing.T) {
 		is.Equal(r.Method, http.MethodPost)
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"data": {
 				"something": "yes"
 			}
@@ -245,7 +245,7 @@ func TestDoErr(t *testing.T) {
 		is.Equal(r.Method, http.MethodPost)
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"errors": [{
 				"message": "Something went wrong"
 			}]
@@ -273,7 +273,7 @@ func TestDoServerErr(t *testing.T) {
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
 		w.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(w, `Internal Server Error`)
+		_, _ = io.WriteString(w, `Internal Server Error`)
 	}))
 	defer srv.Close()
 
@@ -296,7 +296,7 @@ func TestDoBadRequestErr(t *testing.T) {
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
 		w.WriteHeader(http.StatusBadRequest)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"errors": [{
 				"message": "miscellaneous message as to why the the request was bad"
 			}]
@@ -322,7 +322,7 @@ func TestDoNoResponse(t *testing.T) {
 		is.Equal(r.Method, http.MethodPost)
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
-		io.WriteString(w, `{
+		_, _ = io.WriteString(w, `{
 			"data": {
 				"something": "yes"
 			}

--- a/localstorage/localstorage.go
+++ b/localstorage/localstorage.go
@@ -1,3 +1,6 @@
+// Package localstorage stores and reads files on the local filesystem
+// using a configurable base directory. It is intended as a drop-in
+// stand-in for cloud object storage in development and tests.
 package localstorage
 
 import (

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -129,7 +129,10 @@ func (l *logger) Fatal(ctx context.Context, obj any) {
 }
 
 func (l *logger) Panic(obj any) {
-	defer func() { recover() }()
+	// Suppress the panic raised by zerolog so callers receive a logged
+	// stack trace without crashing the process. The recovered value is
+	// intentionally discarded — it carries no useful state once logged.
+	defer func() { _ = recover() }()
 	l.log.Panic().
 		Fields(getPanicStacktrace()).
 		Msg(fmt.Sprint(getCaller(obj)))

--- a/messaging/README.md
+++ b/messaging/README.md
@@ -2,15 +2,15 @@
 
 `import "github.com/downsized-devs/sdk-go/messaging"`
 
-**Stability:** Beta — no tests in package. See [STABILITY.md](../STABILITY.md).
+**Stability:** Stable. See [STABILITY.md](../STABILITY.md).
 
 Push notifications via Firebase Cloud Messaging (FCM). Manages device-token topic subscriptions and broadcasts.
 
 ## Features
 
 - `SubscribeToTopic`, `UnsubscribeFromTopic`
-- `BroadcastToTopic` — send a notification to every device on a topic.
-- `BatchSendDryRun` — validate a batch send without delivering.
+- `BroadcastToTopic` — send a data payload to every device on a topic.
+- `BatchSendDryRun` — validate token batches without delivering; chunked to `MaximumTokensPerBatch` (500) per call.
 
 ## Installation
 
@@ -22,22 +22,29 @@ go get github.com/downsized-devs/sdk-go/messaging
 
 ```go
 m := messaging.Init(messaging.Config{
-    Firebase: messaging.FirebaseConf{ AccountKey: messaging.FirebaseAccountKey{ /* ... */ } },
-}, log, jsonParser)
+    Firebase: messaging.FirebaseConf{
+        AccountKey: messaging.FirebaseAccountKey{ /* ... */ },
+    },
+}, log, jsonParser, nil) // httpClient is deprecated; pass nil
 
-_ = m.SubscribeToTopic(ctx, []string{"deviceToken1"}, "news")
-_ = m.BroadcastToTopic(ctx, "news", "Daily update", "...body...")
+_ = m.SubscribeToTopic(ctx, "deviceToken1", "news")
+_ = m.BroadcastToTopic(ctx, "news", map[string]string{
+    "title": "Daily update",
+    "body":  "...body...",
+})
 ```
 
 ## API Reference
 
 | Symbol | Signature |
 |---|---|
-| `Init` | `func Init(cfg Config, log logger.Interface, json parser.JsonInterface) Interface` |
-| `Interface.SubscribeToTopic` | `(ctx, tokens []string, topic string) error` |
-| `Interface.UnsubscribeFromTopic` | `(ctx, tokens []string, topic string) error` |
-| `Interface.BroadcastToTopic` | `(ctx, topic, title, body string) error` |
-| `Interface.BatchSendDryRun` | `(ctx, [...]) error` |
+| `Init` | `func Init(cfg Config, log logger.Interface, json parser.JsonInterface, _ *http.Client) Interface` |
+| `Interface.SubscribeToTopic` | `(ctx, deviceToken string, topic string) error` |
+| `Interface.UnsubscribeFromTopic` | `(ctx, deviceToken string, topic string) error` |
+| `Interface.BroadcastToTopic` | `(ctx, topic string, payload map[string]string) error` |
+| `Interface.BatchSendDryRun` | `(ctx, tokens []string) ([]string, error)` |
+
+The `httpClient` argument to `Init` is accepted for backwards-compatibility but ignored — see the GoDoc for the `Deprecated:` notice.
 
 ## Configuration
 
@@ -50,7 +57,7 @@ _ = m.BroadcastToTopic(ctx, "news", "Daily update", "...body...")
 
 ## Testing
 
-No tests yet. Use the Firebase Admin SDK's fake-app pattern when adding them.
+Unit tests cover the public surface using a `firebaseMessenger` seam; no network calls are made.
 
 ```bash
 go test ./messaging/...
@@ -58,7 +65,7 @@ go test ./messaging/...
 
 ## Contributing
 
-See [CONTRIBUTING.md](../CONTRIBUTING.md). Test coverage gates promotion to Stable.
+See [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ## Related Packages
 

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -131,33 +131,48 @@ func (m *messaging) BroadcastToTopic(ctx context.Context, topic string, payload 
 	return nil
 }
 
-// Dry run function is to validate a batch of token. If some invalidate, we will unsubscribe it from the topic
+// Dry run function is to validate a batch of token. If some invalidate, we will unsubscribe it from the topic.
+//
+// Firebase rejects MulticastMessages with more than MaximumTokensPerBatch
+// tokens, so the input is chunked and SendMulticastDryRun is called once per
+// chunk; invalid-token results are merged across all chunks.
 func (m *messaging) BatchSendDryRun(ctx context.Context, tokens []string) ([]string, error) {
 	invalidTokens := []string{}
-	message := &firebase_messaging.MulticastMessage{
-		Tokens: tokens,
-		Data: map[string]string{
-			"desc": "dry run to validate token",
-		},
+	if len(tokens) == 0 {
+		return invalidTokens, nil
 	}
 
-	multicastResponse, err := m.firebase.SendMulticastDryRun(ctx, message)
+	hasFailures := false
+	for start := 0; start < len(tokens); start += MaximumTokensPerBatch {
+		end := min(start+MaximumTokensPerBatch, len(tokens))
+		batch := tokens[start:end]
 
-	// As firebase documentation mentioned, this mean that ALL the token is not valid/internal server error within firebase
-	if err != nil {
-		return invalidTokens, err
-	}
-
-	// This means some of the token is not valid
-	if multicastResponse.FailureCount > 0 {
-		for i, response := range multicastResponse.Responses {
-			if response.Error != nil {
-				invalidTokens = append(invalidTokens, tokens[i])
-			}
+		message := &firebase_messaging.MulticastMessage{
+			Tokens: batch,
+			Data: map[string]string{
+				"desc": "dry run to validate token",
+			},
 		}
 
-		return invalidTokens, errors.New("partial error")
+		multicastResponse, err := m.firebase.SendMulticastDryRun(ctx, message)
+		// As firebase documentation mentions, this means the whole batch is
+		// either invalid or hit an internal firebase error.
+		if err != nil {
+			return invalidTokens, err
+		}
+
+		if multicastResponse.FailureCount > 0 {
+			hasFailures = true
+			for i, response := range multicastResponse.Responses {
+				if response.Error != nil {
+					invalidTokens = append(invalidTokens, batch[i])
+				}
+			}
+		}
 	}
 
+	if hasFailures {
+		return invalidTokens, errors.New("partial error")
+	}
 	return invalidTokens, nil
 }

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -1,3 +1,7 @@
+// Package messaging is a thin wrapper over Firebase Cloud Messaging
+// (FCM). It exposes topic subscription management, single-topic
+// broadcasts, and a dry-run helper for validating large batches of
+// device tokens.
 package messaging
 
 import (
@@ -16,6 +20,8 @@ const (
 	MaximumTokensPerBatch = 500
 )
 
+// Interface is the public surface of the messaging package — mockable
+// for tests via the firebaseMessenger seam underneath.
 type Interface interface {
 	SubscribeToTopic(ctx context.Context, deviceToken, topic string) error
 	UnsubscribeFromTopic(ctx context.Context, deviceToken, topic string) error
@@ -56,6 +62,9 @@ type FirebaseConf struct {
 	ApiKey     string
 }
 
+// Config controls how Init builds the messaging client. Setting
+// SkipFirebaseInit short-circuits the live Firebase Cloud Messaging
+// connection — useful for tests.
 type Config struct {
 	SkipFirebaseInit bool
 	Firebase         FirebaseConf

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -61,7 +61,12 @@ type Config struct {
 	Firebase         FirebaseConf
 }
 
-func Init(cfg Config, log logger.Interface, json parser.JsonInterface, httpClient *http.Client) Interface {
+// Init builds a messaging client. The httpClient parameter is ignored
+// because the underlying Firebase SDK manages its own HTTP transport.
+//
+// Deprecated: httpClient is not used and will be removed in v2.0.0. Pass
+// nil for forward-compatibility.
+func Init(cfg Config, log logger.Interface, json parser.JsonInterface, _ *http.Client) Interface {
 	if cfg.SkipFirebaseInit {
 		return &messaging{
 			log: log,

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -3,6 +3,7 @@ package messaging
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	firebase_messaging "firebase.google.com/go/messaging"
@@ -24,6 +25,12 @@ type fakeFirebase struct {
 	multicastMsg *firebase_messaging.MulticastMessage
 	multicastErr error
 	multicastRsp *firebase_messaging.BatchResponse
+	// multicastCalls records each batch passed to SendMulticastDryRun so that
+	// chunking behavior can be asserted from tests.
+	multicastCalls [][]string
+	// multicastRspFor lets callers return different BatchResponses per batch
+	// (indexed by call number). Falls back to multicastRsp when nil/short.
+	multicastRspFor []*firebase_messaging.BatchResponse
 }
 
 func (f *fakeFirebase) SubscribeToTopic(_ context.Context, tokens []string, topic string) (*firebase_messaging.TopicManagementResponse, error) {
@@ -45,7 +52,16 @@ func (f *fakeFirebase) Send(_ context.Context, message *firebase_messaging.Messa
 
 func (f *fakeFirebase) SendMulticastDryRun(_ context.Context, message *firebase_messaging.MulticastMessage) (*firebase_messaging.BatchResponse, error) {
 	f.multicastMsg = message
-	return f.multicastRsp, f.multicastErr
+	callIdx := len(f.multicastCalls)
+	tokensCopy := append([]string(nil), message.Tokens...)
+	f.multicastCalls = append(f.multicastCalls, tokensCopy)
+	if f.multicastErr != nil {
+		return nil, f.multicastErr
+	}
+	if callIdx < len(f.multicastRspFor) && f.multicastRspFor[callIdx] != nil {
+		return f.multicastRspFor[callIdx], nil
+	}
+	return f.multicastRsp, nil
 }
 
 func newMessaging(fake *fakeFirebase) *messaging {
@@ -175,4 +191,70 @@ func TestBatchSendDryRun_AllFailure(t *testing.T) {
 	invalid, err := m.BatchSendDryRun(context.Background(), []string{"a", "b"})
 	require.Error(t, err)
 	assert.Empty(t, invalid)
+}
+
+// TestBatchSendDryRun_ChunksOverMax verifies that requests larger than
+// MaximumTokensPerBatch are split into multiple SendMulticastDryRun calls
+// and that invalid-token results merge across batches.
+func TestBatchSendDryRun_ChunksOverMax(t *testing.T) {
+	const total = MaximumTokensPerBatch + 1
+	tokens := make([]string, total)
+	for i := range tokens {
+		tokens[i] = fmt.Sprintf("tok-%d", i)
+	}
+
+	// First batch (500 tokens) reports one failure at index 0.
+	first := &firebase_messaging.BatchResponse{
+		SuccessCount: MaximumTokensPerBatch - 1,
+		FailureCount: 1,
+		Responses:    make([]*firebase_messaging.SendResponse, MaximumTokensPerBatch),
+	}
+	for i := range first.Responses {
+		first.Responses[i] = &firebase_messaging.SendResponse{Success: true}
+	}
+	first.Responses[0] = &firebase_messaging.SendResponse{Error: errors.New("invalid")}
+
+	// Second batch (1 token) all success.
+	second := &firebase_messaging.BatchResponse{
+		SuccessCount: 1,
+		Responses:    []*firebase_messaging.SendResponse{{Success: true}},
+	}
+
+	fake := &fakeFirebase{multicastRspFor: []*firebase_messaging.BatchResponse{first, second}}
+	m := newMessaging(fake)
+
+	invalid, err := m.BatchSendDryRun(context.Background(), tokens)
+	require.Error(t, err, "partial-error expected when any chunk reports failures")
+	require.Len(t, fake.multicastCalls, 2, "expected two SendMulticastDryRun calls for 501 tokens")
+	assert.Equal(t, MaximumTokensPerBatch, len(fake.multicastCalls[0]))
+	assert.Equal(t, 1, len(fake.multicastCalls[1]))
+	assert.Equal(t, []string{tokens[0]}, invalid)
+}
+
+func TestBatchSendDryRun_ChunksOverMaxAllSuccess(t *testing.T) {
+	const total = MaximumTokensPerBatch + 1
+	tokens := make([]string, total)
+	for i := range tokens {
+		tokens[i] = fmt.Sprintf("tok-%d", i)
+	}
+
+	first := &firebase_messaging.BatchResponse{
+		SuccessCount: MaximumTokensPerBatch,
+		Responses:    make([]*firebase_messaging.SendResponse, MaximumTokensPerBatch),
+	}
+	for i := range first.Responses {
+		first.Responses[i] = &firebase_messaging.SendResponse{Success: true}
+	}
+	second := &firebase_messaging.BatchResponse{
+		SuccessCount: 1,
+		Responses:    []*firebase_messaging.SendResponse{{Success: true}},
+	}
+
+	fake := &fakeFirebase{multicastRspFor: []*firebase_messaging.BatchResponse{first, second}}
+	m := newMessaging(fake)
+
+	invalid, err := m.BatchSendDryRun(context.Background(), tokens)
+	require.NoError(t, err)
+	assert.Empty(t, invalid)
+	require.Len(t, fake.multicastCalls, 2)
 }

--- a/nosql/nosql.go
+++ b/nosql/nosql.go
@@ -3,6 +3,7 @@ package nosql
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"reflect"
 	"strings"
 	"time"
@@ -40,9 +41,9 @@ func Init(cfg Config, log logger.Interface) Interface {
 	client := options.Client().ApplyURI(cfg.DBUrl)
 	dbClient, err := mongo.Connect(ctx, client)
 	if err != nil {
-		log.Fatal(ctx, fmt.Sprintf("[FATAL] cannot connect to dbURL %s, err : %v", cfg.DBUrl, err))
+		log.Fatal(ctx, fmt.Sprintf("[FATAL] cannot connect to dbURL %s, err : %v", redactDSN(cfg.DBUrl), err))
 	}
-	log.Info(ctx, fmt.Sprintf("NoSQL: dbURL=%s db=%s", cfg.DBUrl, cfg.DB))
+	log.Info(ctx, fmt.Sprintf("NoSQL: dbURL=%s db=%s", redactDSN(cfg.DBUrl), cfg.DB))
 
 	nosql := &mongoDB{
 		client: dbClient,
@@ -110,6 +111,26 @@ func (m *mongoDB) UpdateMany(ctx context.Context, collection string, filter inte
 	}
 
 	return updateResult, nil
+}
+
+// redactDSN strips any embedded password from a MongoDB connection URL so
+// that fatal/info logs never expose credentials. If the input cannot be
+// parsed (e.g. malformed), it returns "[redacted]" rather than leak it.
+func redactDSN(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		if err != nil {
+			return "[redacted]"
+		}
+		return raw
+	}
+	if _, hasPassword := u.User.Password(); hasPassword {
+		u.User = url.User(u.User.Username())
+	}
+	return u.String()
 }
 
 // Replace query bindvars with args value

--- a/nosql/nosql_test.go
+++ b/nosql/nosql_test.go
@@ -164,6 +164,26 @@ func TestUpdateMany(t *testing.T) {
 // mtest mock client double-disconnects the mock and panics, so we cover the
 // error-wrap branch via a real client check in integration tests instead.
 
+func TestRedactDSN(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no credentials", "mongodb://host:27017/db", "mongodb://host:27017/db"},
+		{"with password", "mongodb://user:secret@host:27017/db", "mongodb://user@host:27017/db"},
+		{"username only", "mongodb://user@host:27017/db", "mongodb://user@host:27017/db"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactDSN(tt.raw)
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, "secret")
+		})
+	}
+}
+
 func TestReplaceBindvarsWithArgs(t *testing.T) {
 	t.Run("primitive ? placeholders are replaced positionally", func(t *testing.T) {
 		got := replaceBindvarsWithArgs("SELECT ?, ?", 1, "two")

--- a/num/division.go
+++ b/num/division.go
@@ -1,6 +1,11 @@
+// Package num contains numeric utility helpers — currently a safe
+// division primitive that hides divide-by-zero handling behind a
+// configurable fallback.
 package num
 
-// / Checks denominator in a fraction (numerator/denominator) which returns zero value or original value depends on the zeroValue
+// SafeDivision returns numerator/denominator. When denominator is zero
+// the function returns 0 if zeroValue is true; otherwise it returns the
+// numerator unchanged so callers can choose an identity value.
 func SafeDivision(numerator float64, denominator float64, zeroValue bool) float64 {
 	if denominator == 0 {
 		if !zeroValue {

--- a/pdf/pdf.go
+++ b/pdf/pdf.go
@@ -24,8 +24,20 @@ import (
 )
 
 // Default watermark description string passed through to pdfcpu. Callers who
-// need a different font/size/opacity can use AddTextWatermarkWithDesc.
-const defaultWatermarkDesc = "font:Helvetica, points:24, opacity:0.5, scale:0.5"
+// need a different font/size/opacity can use AddTextWatermarkWithDesc. Declared
+// as a var (not const) so tests can swap in an invalid value to exercise the
+// api.TextWatermark error branch.
+var defaultWatermarkDesc = "font:Helvetica, points:24, opacity:0.5, scale:0.5"
+
+// Test seams for filesystem operations used by Split. Production code uses the
+// os.* implementations; tests swap these to drive the error branches that are
+// otherwise unreachable once MkdirTemp has handed us a fresh temp directory.
+var (
+	osMkdirTemp = os.MkdirTemp
+	osWriteFile = os.WriteFile
+	osReadDir   = os.ReadDir
+	osReadFile  = os.ReadFile
+)
 
 type Interface interface {
 	Encrypt(ctx context.Context, data []byte, password string) ([]byte, error)
@@ -110,21 +122,21 @@ func (p *pdf) Split(_ context.Context, data []byte, span int) ([][]byte, error) 
 		return nil, errors.NewWithCode(codes.CodeBadRequest, "pdf: empty input")
 	}
 
-	dir, err := os.MkdirTemp("", "sdkgo-pdf-split-")
+	dir, err := osMkdirTemp("", "sdkgo-pdf-split-")
 	if err != nil {
 		return nil, err
 	}
 	defer os.RemoveAll(dir)
 
 	inPath := filepath.Join(dir, "in.pdf")
-	if err := os.WriteFile(inPath, data, 0o600); err != nil {
+	if err := osWriteFile(inPath, data, 0o600); err != nil {
 		return nil, err
 	}
 	if err := api.SplitFile(inPath, dir, span, model.NewDefaultConfiguration()); err != nil {
 		return nil, err
 	}
 
-	entries, err := os.ReadDir(dir)
+	entries, err := osReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +152,7 @@ func (p *pdf) Split(_ context.Context, data []byte, span int) ([][]byte, error) 
 
 	chunks := make([][]byte, 0, len(names))
 	for _, n := range names {
-		b, err := os.ReadFile(filepath.Join(dir, n))
+		b, err := osReadFile(filepath.Join(dir, n))
 		if err != nil {
 			return nil, err
 		}

--- a/pdf/pdf_test.go
+++ b/pdf/pdf_test.go
@@ -3,6 +3,9 @@ package pdf
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 	"testing"
@@ -22,6 +25,56 @@ func loadExample(t *testing.T) []byte {
 
 func newPDF() Interface {
 	return Init(logger.Init(logger.Config{}))
+}
+
+// buildPDF assembles a tiny PDF with the given object bodies. Each body must be
+// the full "N 0 obj ... endobj\n" string. Returns the bytes plus byte offsets
+// for the supplied objects (1-indexed). It also writes a valid xref table and
+// startxref/EOF so ledongpdf.NewReader accepts it.
+func buildPDF(bodies ...string) []byte {
+	var buf bytes.Buffer
+	write := func(s string) int {
+		off := buf.Len()
+		buf.WriteString(s)
+		return off
+	}
+
+	write("%PDF-1.4\n")
+	offsets := make([]int, len(bodies))
+	for i, body := range bodies {
+		offsets[i] = write(body)
+	}
+	xref := buf.Len()
+	write(fmt.Sprintf("xref\n0 %d\n", len(bodies)+1))
+	write("0000000000 65535 f \n")
+	for _, off := range offsets {
+		write(fmt.Sprintf("%010d 00000 n \n", off))
+	}
+	write(fmt.Sprintf("trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF",
+		len(bodies)+1, xref))
+	return buf.Bytes()
+}
+
+// nullPagePDF reports Count=1 but has an empty /Kids array, so r.Page(1) falls
+// through Reader.Page's search loop and returns Page{} — i.e. p.V.IsNull().
+func nullPagePDF() []byte {
+	return buildPDF(
+		"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+		"2 0 obj\n<< /Type /Pages /Kids [] /Count 1 >>\nendobj\n",
+	)
+}
+
+// brokenContentPDF has a real /Page whose /Contents stream contains a bare
+// "Tj" operator with no operands. GetPlainText's Interpret callback panics on
+// `len(args) != 1`, and the deferred recover surfaces that as an error.
+func brokenContentPDF() []byte {
+	const content = "Tj"
+	return buildPDF(
+		"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+		"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+		"3 0 obj\n<< /Type /Page /Parent 2 0 R /Contents 4 0 R /MediaBox [0 0 612 792] >>\nendobj\n",
+		fmt.Sprintf("4 0 obj\n<< /Length %d >>\nstream\n%s\nendstream\nendobj\n", len(content), content),
+	)
 }
 
 func TestInit_ReturnsInterface(t *testing.T) {
@@ -57,7 +110,6 @@ func TestEncrypt_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, decrypted)
 
-	// After decrypt → re-encrypt cycle we should be able to read the page count again.
 	n, err := p.PageCount(context.Background(), decrypted)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, n, 1)
@@ -98,7 +150,6 @@ func TestMerge_SinglePartReturnsCopy(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, data, got)
 
-	// Mutating the result must not mutate the input.
 	if len(got) > 0 {
 		got[0] ^= 0xFF
 		assert.NotEqual(t, got[0], data[0])
@@ -125,7 +176,6 @@ func TestSplit(t *testing.T) {
 	pages, err := p.PageCount(context.Background(), data)
 	require.NoError(t, err)
 	if pages < 2 {
-		// The fixture is single-page; build a multi-page fixture by merging.
 		data, err = p.Merge(context.Background(), data, data, data)
 		require.NoError(t, err)
 		pages = 3
@@ -155,6 +205,58 @@ func TestSplit_EmptyInput(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestSplit_MkdirTempError forces os.MkdirTemp to fail by pointing TMPDIR at a
+// path that doesn't exist. This exercises the first error return in Split.
+func TestSplit_MkdirTempError(t *testing.T) {
+	t.Setenv("TMPDIR", "/nonexistent/path/that/should/never/exist/sdkgo-pdf-test")
+	p := newPDF()
+	_, err := p.Split(context.Background(), loadExample(t), 1)
+	assert.Error(t, err)
+}
+
+// TestSplit_WriteFileError swaps the WriteFile hook to drive Split's
+// "could not stage input" error branch — unreachable under a fresh temp dir
+// otherwise.
+func TestSplit_WriteFileError(t *testing.T) {
+	sentinel := errors.New("write failed")
+	orig := osWriteFile
+	osWriteFile = func(string, []byte, fs.FileMode) error { return sentinel }
+	t.Cleanup(func() { osWriteFile = orig })
+
+	p := newPDF()
+	_, err := p.Split(context.Background(), loadExample(t), 1)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+}
+
+// TestSplit_ReadDirError swaps the ReadDir hook so Split fails after a
+// successful split. The temp dir is cleaned up via the production defer.
+func TestSplit_ReadDirError(t *testing.T) {
+	sentinel := errors.New("readdir failed")
+	orig := osReadDir
+	osReadDir = func(string) ([]fs.DirEntry, error) { return nil, sentinel }
+	t.Cleanup(func() { osReadDir = orig })
+
+	p := newPDF()
+	_, err := p.Split(context.Background(), loadExample(t), 1)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+}
+
+// TestSplit_ReadFileError swaps ReadFile so the chunk-collection loop in Split
+// fails on the first chunk emitted by pdfcpu.
+func TestSplit_ReadFileError(t *testing.T) {
+	sentinel := errors.New("readfile failed")
+	orig := osReadFile
+	osReadFile = func(string) ([]byte, error) { return nil, sentinel }
+	t.Cleanup(func() { osReadFile = orig })
+
+	p := newPDF()
+	_, err := p.Split(context.Background(), loadExample(t), 1)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+}
+
 func TestAddTextWatermark(t *testing.T) {
 	p := newPDF()
 	data := loadExample(t)
@@ -162,7 +264,6 @@ func TestAddTextWatermark(t *testing.T) {
 	stamped, err := p.AddTextWatermark(context.Background(), data, "CONFIDENTIAL")
 	require.NoError(t, err)
 	assert.NotEmpty(t, stamped)
-	// Watermarking changes the byte stream.
 	assert.False(t, bytes.Equal(data, stamped))
 }
 
@@ -179,13 +280,26 @@ func TestAddTextWatermark_EmptyInput(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestAddTextWatermark_DescriptorParseError swaps the package-level watermark
+// description with one pdfcpu's parser will reject ("font" without a value),
+// covering the api.TextWatermark error branch that the hardcoded valid
+// descriptor never exercises.
+func TestAddTextWatermark_DescriptorParseError(t *testing.T) {
+	orig := defaultWatermarkDesc
+	defaultWatermarkDesc = "not-a-valid-descriptor-format"
+	t.Cleanup(func() { defaultWatermarkDesc = orig })
+
+	p := newPDF()
+	_, err := p.AddTextWatermark(context.Background(), loadExample(t), "WM")
+	assert.Error(t, err)
+}
+
 func TestExtractText(t *testing.T) {
 	p := newPDF()
 	data := loadExample(t)
 
 	txt, err := p.ExtractText(context.Background(), data)
 	require.NoError(t, err)
-	// ExtractText output for the fixture isn't strictly defined; assert basic invariants only.
 	_ = txt
 	assert.NotPanics(t, func() {
 		_ = strings.TrimSpace(txt)
@@ -196,6 +310,27 @@ func TestExtractText_EmptyInput(t *testing.T) {
 	p := newPDF()
 	_, err := p.ExtractText(context.Background(), nil)
 	assert.Error(t, err)
+}
+
+// TestExtractText_NullPageSkipped feeds in a PDF whose /Pages dictionary
+// advertises a Count of 1 but has an empty /Kids list. ledongpdf.NumPage
+// returns 1, but r.Page(1).V.IsNull() is true, so the loop hits `continue`
+// and ExtractText returns an empty string with no error.
+func TestExtractText_NullPageSkipped(t *testing.T) {
+	p := newPDF()
+	txt, err := p.ExtractText(context.Background(), nullPagePDF())
+	require.NoError(t, err)
+	assert.Equal(t, "", txt)
+}
+
+// TestExtractText_GetPlainTextError feeds a PDF with a real page whose
+// /Contents stream is a bare "Tj" operator. GetPlainText's interpreter panics
+// on the empty operand stack and the deferred recover surfaces it as an error.
+func TestExtractText_GetPlainTextError(t *testing.T) {
+	p := newPDF()
+	_, err := p.ExtractText(context.Background(), brokenContentPDF())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Tj")
 }
 
 // garbage is a non-empty byte slice that is syntactically not a PDF. Used to
@@ -217,7 +352,6 @@ func TestRemovePassword_InvalidPDF(t *testing.T) {
 func TestMerge_InvalidPart(t *testing.T) {
 	p := newPDF()
 	data := loadExample(t)
-	// Two non-empty inputs forces api.MergeRaw, where the garbage part fails.
 	_, err := p.Merge(context.Background(), data, garbage)
 	assert.Error(t, err)
 }

--- a/query/README.md
+++ b/query/README.md
@@ -9,9 +9,14 @@ Dynamic SQL clause builder driven by struct tags. Builds WHERE, ORDER BY, LIMIT,
 ## Features
 
 - Struct-tag-driven WHERE clause builder (matches db/param/field tags)
-- Cursor-based pagination (`Cursor` interface)
 - Sort param normalisation (`sort_by`, `sort-by`, `sortBy`, `sortby` all accepted)
 - Typed converters for int/int8/.../uint64, float, string, bool, time, plus their `*Arr` variants
+
+> **Cursor pagination:** the `Cursor` interface is present as a placeholder
+> for a future implementation; the builder does not yet apply cursor
+> filtering automatically. Callers that need keyset pagination today must
+> append the cursor predicate manually via `AddPrefixQuery` (or equivalent)
+> on the parameter struct before handing it to the builder.
 
 ## Installation
 

--- a/query/converter.go
+++ b/query/converter.go
@@ -1,3 +1,7 @@
+// Package query is a struct-tag-driven SQL clause builder. It turns a
+// typed parameter struct (matching `db` / `param` / `field` tags) into
+// WHERE, ORDER BY, LIMIT, and OFFSET fragments that the sql package can
+// execute.
 package query
 
 import (

--- a/query/sql_builder.go
+++ b/query/sql_builder.go
@@ -15,6 +15,10 @@ import (
 
 const cursorField = "cursorField"
 
+// sortClauseRegex is compiled once for use by sqlClausebuilder.sort so that
+// every call no longer pays the regexp.MustCompile cost.
+var sortClauseRegex = regexp.MustCompile(`(?P<sign>-)?(?P<col>[a-zA-Z_\.0-9]+),?`)
+
 type Cursor interface {
 	DecodeCursor(v string) error
 	EncodeCursor() (string, error)
@@ -226,8 +230,8 @@ func (s *sqlClausebuilder) BuildUpdate(update interface{}, where interface{}) (s
 }
 
 func (s *sqlClausebuilder) sort() {
+	reg := sortClauseRegex
 	for _, param := range s.paramSortBy {
-		reg := regexp.MustCompile(`(?P<sign>-)?(?P<col>[a-zA-Z_\.0-9]+),?`)
 		if reg.MatchString(param) {
 			for _, _s := range strings.Split(param, ",") {
 				direction := "ASC"

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -25,14 +25,24 @@ const (
 	Sunday    = "sunday"
 )
 
+// Interface is the public surface of the scheduler. Start kicks off
+// the underlying gocron engine, Shutdown drains it, and Register adds a
+// new job described by opt that runs handlerFunc on schedule.
 type Interface interface {
 	Start(ctx context.Context)
 	Shutdown(ctx context.Context)
 	Register(ctx context.Context, opt JobOption, handlerFunc any) error
 }
 
+// Config is currently empty; it exists so that callers wire scheduler
+// the same way as the other Init-style packages and so future
+// configuration can be added without breaking the API.
 type Config struct{}
 
+// JobOption describes a single registered job. JobType selects the
+// scheduling strategy (see the package-level Duration, Daily, Weekly,
+// Monthly, RandomDuration constants); the other fields apply
+// conditionally based on the JobType chosen.
 type JobOption struct {
 	JobType     string
 	Duration    time.Duration
@@ -47,6 +57,9 @@ type scheduler struct {
 	engine gocron.Scheduler
 }
 
+// Init constructs a scheduler. It panics (through log.Panic) if the
+// underlying gocron engine cannot be created — fail-fast on a
+// misconfigured environment.
 func Init(cfg Config, log logger.Interface) Interface {
 	engine, err := gocron.NewScheduler()
 	if err != nil {

--- a/security/security.go
+++ b/security/security.go
@@ -157,7 +157,10 @@ func (s *security) HashPassword(ctx context.Context, secretKey, password string)
 }
 
 func (s *security) CompareHashPassword(ctx context.Context, secretKey, hashPassword, password string) bool {
-	return hashPassword == s.HashPassword(ctx, secretKey, password)
+	// Use subtle.ConstantTimeCompare to guard against timing side-channels
+	// that string equality would otherwise expose.
+	expected := s.HashPassword(ctx, secretKey, password)
+	return subtle.ConstantTimeCompare([]byte(hashPassword), []byte(expected)) == 1
 }
 
 func (s *security) ScryptPassword(ctx context.Context, salt string, password string) string {

--- a/sql/README.md
+++ b/sql/README.md
@@ -8,7 +8,7 @@ Multi-driver (`MySQL`, `Postgres`, `SQLite`) database client built on `sqlx`, wi
 
 ## Features
 
-- Leader/follower routing (`Leader(ctx)`, `Follower(ctx)`)
+- Leader/follower routing (`Leader()`, `Follower()`)
 - Multi-driver: `github.com/go-sql-driver/mysql`, `github.com/lib/pq`, `modernc.org/sqlite`
 - Transactions with `BeginTx`
 - Prepared statements (`Prepare`)
@@ -33,21 +33,31 @@ import (
 )
 
 log := logger.Init(logger.Config{Level: "info"})
-metrics := instrument.Init(instrument.Config{Enabled: true})
+metrics := instrument.Init(instrument.Config{
+    Metrics: instrument.MetricsConfig{Enabled: true},
+})
 
 db := sql.Init(sql.Config{
     Driver: "postgres",
     Leader: sql.ConnConfig{
-        DSN: "postgres://user:pass@leader:5432/app?sslmode=disable",
+        Host:     "leader",
+        Port:     5432,
+        DB:       "app",
+        User:     "user",
+        Password: "pass",
     },
     Follower: sql.ConnConfig{
-        DSN: "postgres://user:pass@follower:5432/app?sslmode=disable",
+        Host:     "follower",
+        Port:     5432,
+        DB:       "app",
+        User:     "user",
+        Password: "pass",
     },
 }, log, metrics)
 defer db.Stop()
 
 var u User
-if err := db.Follower(ctx).Get(ctx, &u, "SELECT * FROM users WHERE id=$1", 1); err != nil {
+if err := db.Follower().Get(ctx, &u, "SELECT * FROM users WHERE id=$1", 1); err != nil {
     if errors.Is(err, sql.ErrNotFound) { /* miss */ }
 }
 ```
@@ -56,10 +66,10 @@ if err := db.Follower(ctx).Get(ctx, &u, "SELECT * FROM users WHERE id=$1", 1); e
 
 | Symbol | Signature |
 |---|---|
-| `Init` | `func Init(cfg Config, log logger.Interface, metrics instrument.Interface) Interface` |
-| `Interface.Leader` | `(ctx) Command` — read/write connection. |
-| `Interface.Follower` | `(ctx) Command` — read-only connection. |
-| `Interface.Stop` | `() error` — close all pools. |
+| `Init` | `func Init(cfg Config, log logger.Interface, instr instrument.Interface) Interface` |
+| `Interface.Leader` | `() Command` — read/write connection. |
+| `Interface.Follower` | `() Command` — read-only connection. |
+| `Interface.Stop` | `()` — close all pools. |
 | `Command.Query` | `(ctx, dest, q, args...) error` |
 | `Command.Exec` | `(ctx, q, args...) (Result, error)` |
 | `Command.Get` | `(ctx, dest, q, args...) error` — single row. |
@@ -72,16 +82,16 @@ if err := db.Follower(ctx).Get(ctx, &u, "SELECT * FROM users WHERE id=$1", 1); e
 
 | Field | Required | Description |
 |---|---|---|
-| `Driver` | yes | `mysql`, `postgres`, or `sqlite`. |
-| `Leader.DSN` / `Follower.DSN` | yes | Connection strings. |
-| `Leader.MaxOpen`, `MaxIdle`, `MaxLifetime` | no | Pool tuning. Same for follower. |
+| `Driver` | yes | `mysql`, `postgres`, or `sqlite3`. |
+| `Leader` / `Follower` | yes | `ConnConfig{Host, Port, DB, User, Password, SSL, Schema, Options}`. |
+| `Leader.Options.MaxOpen`, `MaxIdle`, `MaxLifeTime` | no | Pool tuning. Same for follower. |
 
 ## Examples
 
 ### Run a transaction
 
 ```go
-tx, err := db.Leader(ctx).BeginTx(ctx, sql.TxOptions{})
+tx, err := db.Leader().BeginTx(ctx, sql.TxOptions{})
 if err != nil { return err }
 defer tx.Rollback()
 
@@ -94,7 +104,7 @@ return tx.Commit()
 ### Use a prepared statement
 
 ```go
-stmt, _ := db.Leader(ctx).Prepare(ctx, "INSERT INTO events(name, payload) VALUES (?, ?)")
+stmt, _ := db.Leader().Prepare(ctx, "INSERT INTO events(name, payload) VALUES (?, ?)")
 defer stmt.Close()
 for _, e := range events {
     _, _ = stmt.Exec(ctx, e.Name, e.Payload)

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -1,3 +1,6 @@
+// Package sql is a sqlx-backed SQL client with leader/follower routing,
+// transactions, prepared statements, and optional Prometheus
+// instrumentation. It targets MySQL, Postgres, and SQLite drivers.
 package sql
 
 import (
@@ -24,6 +27,10 @@ const (
 	connTypeFollower = "follower"
 )
 
+// Config controls how Init builds the SQL client: which driver to use,
+// connection settings for the leader and follower, whether to emit
+// instrumentation metrics, and whether to log every query (useful in
+// development and noisy in production).
 type Config struct {
 	UseInstrument bool
 	LogQuery      bool
@@ -33,6 +40,10 @@ type Config struct {
 	Follower      ConnConfig
 }
 
+// ConnConfig describes a single connection. MockDB, when non-nil, is
+// preferred over the Host/Port/DB/User/Password fields and lets tests
+// inject a pre-built *sql.DB (for example a sqlmock or an in-memory
+// sqlite database).
 type ConnConfig struct {
 	Host     string
 	Port     int
@@ -45,12 +56,17 @@ type ConnConfig struct {
 	MockDB   *sql.DB
 }
 
+// ConnOptions tunes the underlying database/sql pool.
 type ConnOptions struct {
 	MaxLifeTime time.Duration
 	MaxIdle     int
 	MaxOpen     int
 }
 
+// Interface is the public surface of the sql package. Leader returns
+// the read/write Command, Follower returns the read-only Command (or
+// the leader when no follower is configured), and Stop closes both
+// pools at most once.
 type Interface interface {
 	Leader() Command
 	Follower() Command
@@ -66,6 +82,10 @@ type sqlDB struct {
 	instrument instrument.Interface
 }
 
+// Init constructs a sql client from cfg. When cfg.Driver is "sqlmock"
+// instrumentation is force-disabled. cfg.Name defaults to cfg.Driver
+// when empty. Init calls log.Fatal if the leader connection cannot be
+// established.
 func Init(cfg Config, log logger.Interface, instr instrument.Interface) Interface {
 	if cfg.Driver == "sqlmock" {
 		cfg.UseInstrument = false

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -137,12 +137,12 @@ func (s *sqlDB) connect(toLeader bool) (*sqlx.DB, error) {
 	}
 
 	if !toLeader {
-		if s.cfg.Leader.MockDB != nil {
-			return sqlx.NewDb(s.cfg.Leader.MockDB, s.cfg.Driver), nil
-		}
-	} else {
 		if s.cfg.Follower.MockDB != nil {
 			return sqlx.NewDb(s.cfg.Follower.MockDB, s.cfg.Driver), nil
+		}
+	} else {
+		if s.cfg.Leader.MockDB != nil {
+			return sqlx.NewDb(s.cfg.Leader.MockDB, s.cfg.Driver), nil
 		}
 	}
 
@@ -177,10 +177,12 @@ func (s *sqlDB) connect(toLeader bool) (*sqlx.DB, error) {
 }
 
 func (s *sqlDB) isFollowerEnabled() bool {
-	isHostNotEmpty := s.cfg.Follower.Host != ""
-	isHostDifferent := (s.cfg.Follower.Host != s.cfg.Leader.Host && s.cfg.Follower.Port == s.cfg.Leader.Port)
-	isPortDifferent := (s.cfg.Follower.Host == s.cfg.Leader.Host && s.cfg.Follower.Port != s.cfg.Leader.Port)
-	return isHostNotEmpty && (isHostDifferent || isPortDifferent)
+	if s.cfg.Follower.Host == "" {
+		return false
+	}
+	leaderAddr := fmt.Sprintf("%s:%d", s.cfg.Leader.Host, s.cfg.Leader.Port)
+	followerAddr := fmt.Sprintf("%s:%d", s.cfg.Follower.Host, s.cfg.Follower.Port)
+	return leaderAddr != followerAddr
 }
 
 func (s *sqlDB) getURI(conf ConnConfig) (string, error) {

--- a/sql/sql_unit_test.go
+++ b/sql/sql_unit_test.go
@@ -1,0 +1,85 @@
+package sql
+
+import (
+	"database/sql"
+	"testing"
+
+	mock_log "github.com/downsized-devs/sdk-go/tests/mock/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func newMemSqliteDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestLeaderFollowerRoutingWithMockDB verifies that when both leader and
+// follower MockDBs are injected, Leader() returns the leader mock and
+// Follower() returns the follower mock.
+func TestLeaderFollowerRoutingWithMockDB(t *testing.T) {
+	leaderDB := newMemSqliteDB(t)
+	followerDB := newMemSqliteDB(t)
+
+	ctrl := gomock.NewController(t)
+	log := mock_log.NewMockInterface(ctrl)
+	log.EXPECT().Info(gomock.Any(), gomock.Any()).AnyTimes()
+	log.EXPECT().Error(gomock.Any(), gomock.Any()).AnyTimes()
+	log.EXPECT().Fatal(gomock.Any(), gomock.Any()).AnyTimes()
+
+	db := Init(Config{
+		Driver: "sqlmock",
+		Name:   "test",
+		Leader: ConnConfig{
+			Host:   "leader-host",
+			Port:   1111,
+			MockDB: leaderDB,
+		},
+		Follower: ConnConfig{
+			Host:   "follower-host",
+			Port:   2222,
+			MockDB: followerDB,
+		},
+	}, log, nil)
+
+	leaderCmd := db.Leader()
+	followerCmd := db.Follower()
+	require.NotNil(t, leaderCmd)
+	require.NotNil(t, followerCmd)
+
+	leaderInner, ok := leaderCmd.(*command)
+	require.True(t, ok)
+	followerInner, ok := followerCmd.(*command)
+	require.True(t, ok)
+
+	assert.Same(t, leaderDB, leaderInner.db.DB, "Leader() should wrap the leader MockDB")
+	assert.Same(t, followerDB, followerInner.db.DB, "Follower() should wrap the follower MockDB")
+}
+
+// TestIsFollowerEnabled covers the host/port detection edge cases that 1c
+// addresses, including "both host and port differ".
+func TestIsFollowerEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		leader ConnConfig
+		fol    ConnConfig
+		want   bool
+	}{
+		{"no follower host", ConnConfig{Host: "a", Port: 1}, ConnConfig{Host: "", Port: 1}, false},
+		{"identical addr", ConnConfig{Host: "a", Port: 1}, ConnConfig{Host: "a", Port: 1}, false},
+		{"different host only", ConnConfig{Host: "a", Port: 1}, ConnConfig{Host: "b", Port: 1}, true},
+		{"different port only", ConnConfig{Host: "a", Port: 1}, ConnConfig{Host: "a", Port: 2}, true},
+		{"both host and port differ", ConnConfig{Host: "a", Port: 1}, ConnConfig{Host: "b", Port: 2}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &sqlDB{cfg: Config{Leader: tt.leader, Follower: tt.fol}}
+			assert.Equal(t, tt.want, s.isFollowerEnabled())
+		})
+	}
+}

--- a/storage/README.md
+++ b/storage/README.md
@@ -22,16 +22,17 @@ go get github.com/downsized-devs/sdk-go/storage
 
 ```go
 s := storage.Init(storage.Config{
-    AWS: storage.AWSS3Config{
-        Region:    "ap-southeast-1",
-        Bucket:    "my-bucket",
-        AccessKey: "<KEY>",
-        Secret:    "<SECRET>",
+    AWSS3: storage.AWSS3Config{
+        Region:          "ap-southeast-1",
+        BucketName:      "my-bucket",
+        AccessKeyID:     "<KEY>",
+        SecretAccessKey: "<SECRET>",
+        PresignDuration: 15 * time.Minute,
     },
 }, log)
 
-_ = s.Upload(ctx, "key/path.jpg", fileReader, "image/jpeg")
-url, _ := s.GetPresignedUrl(ctx, "key/path.jpg")
+url, _ := s.Upload(ctx, "key/path.jpg", "path.jpg", "image/jpeg", fileBytes)
+presigned, _ := s.GetPresignedUrl(ctx, "key/path.jpg")
 ```
 
 ## API Reference
@@ -39,7 +40,7 @@ url, _ := s.GetPresignedUrl(ctx, "key/path.jpg")
 | Symbol | Signature |
 |---|---|
 | `Init` | `func Init(cfg Config, log logger.Interface) Interface` |
-| `Interface.Upload` | `(ctx, key string, body io.Reader, contentType string) error` |
+| `Interface.Upload` | `(ctx, key string, filename, contentType string, data []byte) (url string, err error)` |
 | `Interface.Download` | `(ctx, key string) ([]byte, error)` |
 | `Interface.Delete` | `(ctx, key string) error` |
 | `Interface.GetPresignedUrl` | `(ctx, key string) (string, error)` |
@@ -50,9 +51,10 @@ url, _ := s.GetPresignedUrl(ctx, "key/path.jpg")
 
 | Field | Required | Description |
 |---|---|---|
-| `AWS.Region` | yes | S3 region. |
-| `AWS.Bucket` | yes | Default bucket. |
-| `AWS.AccessKey` / `AWS.Secret` | yes | IAM credentials. Use IRSA / IAM-role-for-service-account in EKS instead when possible. |
+| `AWSS3.Region` | yes | S3 region. |
+| `AWSS3.BucketName` | yes | Default bucket. |
+| `AWSS3.AccessKeyID` / `AWSS3.SecretAccessKey` | yes | IAM credentials. Use IRSA / IAM-role-for-service-account in EKS instead when possible. |
+| `AWSS3.PresignDuration` | no | Default expiry used by `GetPresignedUrl`. |
 
 ## Error Handling
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -95,21 +95,18 @@ func (s *storage) Download(ctx context.Context, key string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.NewWithCode(codes.CodeStorageS3Download, "failed to download file, with err: %v", err)
 	}
-
-	size := int(*obj.ContentLength)
-	buffer := make([]byte, size)
 	defer obj.Body.Close()
-	var bbuffer bytes.Buffer
-	for {
-		byteSize, err := obj.Body.Read(buffer)
-		if byteSize > 0 {
-			bbuffer.Write(buffer[:byteSize])
-		} else if err == io.EOF || err != nil {
-			break
-		}
+
+	data, err := io.ReadAll(obj.Body)
+	if err != nil {
+		return nil, errors.NewWithCode(codes.CodeStorageS3Download, "failed to read object body for key %s: %v", key, err)
 	}
 
-	return bbuffer.Bytes(), nil
+	if obj.ContentLength != nil && int64(len(data)) != *obj.ContentLength {
+		return nil, errors.NewWithCode(codes.CodeStorageS3Download, "short read for key %s: got %d bytes, expected %d", key, len(data), *obj.ContentLength)
+	}
+
+	return data, nil
 }
 
 func (s *storage) Delete(ctx context.Context, key string) error {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,3 +1,6 @@
+// Package storage wraps the AWS S3 v1 SDK with a small Interface
+// covering upload, download, delete, presigned URL generation, and
+// static URL construction.
 package storage
 
 import (
@@ -17,6 +20,7 @@ import (
 	"github.com/downsized-devs/sdk-go/logger"
 )
 
+// Interface is the public surface of the storage package. Mockable for tests.
 type Interface interface {
 	Upload(ctx context.Context, key string, filename, filemimetype string, data []byte) (url string, err error)
 	Download(ctx context.Context, url string) ([]byte, error)
@@ -26,10 +30,13 @@ type Interface interface {
 	CreateUrlByKey(key string) string
 }
 
+// Config wraps the AWS-specific options consumed by Init.
 type Config struct {
 	AWSS3 AWSS3Config
 }
 
+// AWSS3Config carries the bucket, region, IAM credentials, and the
+// default presign duration applied by GetPresignedUrl.
 type AWSS3Config struct {
 	Region          string
 	BucketName      string
@@ -53,6 +60,9 @@ type storage struct {
 	log    logger.Interface
 }
 
+// Init constructs an S3-backed storage client. It calls log.Fatal when
+// the configured credentials are empty so misconfigured services fail
+// fast at startup rather than at the first request.
 func Init(cfg Config, log logger.Interface) Interface {
 	if cfg.AWSS3.AccessKeyID == "" || cfg.AWSS3.SecretAccessKey == "" {
 		log.Fatal(context.Background(), "storage credentials not found")

--- a/storage/storage_extra_test.go
+++ b/storage/storage_extra_test.go
@@ -28,6 +28,15 @@ type fakeS3 struct {
 	getInput *s3.GetObjectInput
 	getBody  []byte
 	getErr   error
+	// getBodyOverride, if non-nil, is returned as the GetObjectOutput body
+	// instead of wrapping getBody in a NopCloser.
+	getBodyOverride io.ReadCloser
+	// getContentLengthOverride, if non-nil, replaces the auto-derived
+	// ContentLength on the GetObjectOutput.
+	getContentLengthOverride *int64
+	// getNilContentLength forces the response ContentLength to be nil,
+	// regardless of getContentLengthOverride.
+	getNilContentLength bool
 
 	deleteInput *s3.DeleteObjectInput
 	deleteErr   error
@@ -49,12 +58,21 @@ func (f *fakeS3) GetObjectWithContext(_ aws.Context, in *s3.GetObjectInput, _ ..
 	if f.getErr != nil {
 		return nil, f.getErr
 	}
-	body := io.NopCloser(bytes.NewReader(f.getBody))
+	var body io.ReadCloser = io.NopCloser(bytes.NewReader(f.getBody))
+	if f.getBodyOverride != nil {
+		body = f.getBodyOverride
+	}
 	size := int64(len(f.getBody))
-	return &s3.GetObjectOutput{
-		Body:          body,
-		ContentLength: &size,
-	}, nil
+	out := &s3.GetObjectOutput{Body: body}
+	switch {
+	case f.getNilContentLength:
+		out.ContentLength = nil
+	case f.getContentLengthOverride != nil:
+		out.ContentLength = f.getContentLengthOverride
+	default:
+		out.ContentLength = &size
+	}
+	return out, nil
 }
 
 func (f *fakeS3) DeleteObjectWithContext(_ aws.Context, in *s3.DeleteObjectInput, _ ...request.Option) (*s3.DeleteObjectOutput, error) {
@@ -146,6 +164,53 @@ func TestDownload_Error(t *testing.T) {
 	s := newStorage(t, fake)
 	_, err := s.Download(context.Background(), "k")
 	assert.Error(t, err)
+}
+
+// erroringReader returns a slice of bytes once and then a non-EOF error,
+// simulating a network/body failure partway through the stream.
+type erroringReader struct {
+	chunk   []byte
+	sent    bool
+	failErr error
+}
+
+func (e *erroringReader) Read(p []byte) (int, error) {
+	if !e.sent {
+		e.sent = true
+		n := copy(p, e.chunk)
+		return n, nil
+	}
+	return 0, e.failErr
+}
+
+func (e *erroringReader) Close() error { return nil }
+
+func TestDownload_PropagatesReadError(t *testing.T) {
+	fake := &fakeS3{
+		getBodyOverride: &erroringReader{chunk: []byte("partial"), failErr: errors.New("network glitch")},
+	}
+	// Force ContentLength to a non-matching positive value to make sure
+	// the body-read path is exercised even with a non-nil length.
+	cl := int64(1024)
+	fake.getContentLengthOverride = &cl
+	s := newStorage(t, fake)
+
+	_, err := s.Download(context.Background(), "k")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network glitch")
+}
+
+func TestDownload_NilContentLengthIsSafe(t *testing.T) {
+	body := []byte("payload")
+	fake := &fakeS3{
+		getBodyOverride:     io.NopCloser(bytes.NewReader(body)),
+		getNilContentLength: true,
+	}
+	s := newStorage(t, fake)
+
+	got, err := s.Download(context.Background(), "k")
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
 }
 
 // ---------------- Delete ---------------- //

--- a/storage/storage_extra_test.go
+++ b/storage/storage_extra_test.go
@@ -58,7 +58,7 @@ func (f *fakeS3) GetObjectWithContext(_ aws.Context, in *s3.GetObjectInput, _ ..
 	if f.getErr != nil {
 		return nil, f.getErr
 	}
-	var body io.ReadCloser = io.NopCloser(bytes.NewReader(f.getBody))
+	body := io.ReadCloser(io.NopCloser(bytes.NewReader(f.getBody)))
 	if f.getBodyOverride != nil {
 		body = f.getBodyOverride
 	}

--- a/stringlib/string.go
+++ b/stringlib/string.go
@@ -1,3 +1,5 @@
+// Package stringlib provides string utilities: random-string generation,
+// trimming, case helpers, and other small reusable string operations.
 package stringlib
 
 import "math/rand"

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -1,3 +1,5 @@
+// Package tracker pushes ad-hoc counter metrics to a Prometheus
+// PushGateway and forwards event payloads to a configured webhook URL.
 package tracker
 
 import (

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -76,10 +76,9 @@ func (t *tracker) Push(ctx context.Context, trackingName string, labels map[stri
 
 	opsProcessed.Inc()
 
-	conn := fmt.Sprintf("%s:%s", t.opt.URL, t.opt.Port)
-	if conn == "" {
-		conn = fmt.Sprintf("%s:%s", defaultURL, defaultPort)
-	}
+	url := operator.Ternary(t.opt.URL != "", t.opt.URL, defaultURL)
+	port := operator.Ternary(t.opt.Port != "", t.opt.Port, defaultPort)
+	conn := fmt.Sprintf("%s:%s", url, port)
 
 	jobName := operator.Ternary(t.opt.JobName != "", t.opt.JobName, defaultJobName)
 	timeout := operator.Ternary(t.opt.Timeout > 0, t.opt.Timeout, defaultTimeout)
@@ -113,13 +112,14 @@ func (t *tracker) PushWebhook(ctx context.Context, payload []byte, headers map[s
 	if err != nil {
 		return errors.NewWithCode(codes.CodeErrorHttpDo, "%s", err.Error())
 	}
+	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.NewWithCode(codes.CodeErrorIoutilReadAll, "%s", err.Error())
 	}
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return errors.NewWithCode(codes.CodeErrorHttpDo, "send event webhook error: %s", string(body))
 	}
 

--- a/tracker/tracker_unit_test.go
+++ b/tracker/tracker_unit_test.go
@@ -1,0 +1,52 @@
+package tracker
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/downsized-devs/sdk-go/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPushWebhook_Disabled verifies that the webhook is a no-op when disabled.
+func TestPushWebhook_Disabled(t *testing.T) {
+	tr := Init(Options{}, logger.Init(logger.Config{}))
+	require.NoError(t, tr.PushWebhook(context.Background(), []byte("x"), nil))
+}
+
+// TestPushWebhook_Success exercises the happy path through an httptest server
+// and asserts the body / headers are forwarded.
+func TestPushWebhook_Success(t *testing.T) {
+	var gotHeader string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-Test")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := Init(Options{Webhook: WebhookOptions{Enabled: true, URL: srv.URL}}, logger.Init(logger.Config{}))
+	err := tr.PushWebhook(context.Background(), []byte("payload"), map[string]string{"X-Test": "yes"})
+	require.NoError(t, err)
+	assert.Equal(t, "yes", gotHeader)
+	assert.Equal(t, []byte("payload"), gotBody)
+}
+
+// TestPushWebhook_Non200ReturnsError covers the non-OK branch.
+func TestPushWebhook_Non200ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	tr := Init(Options{Webhook: WebhookOptions{Enabled: true, URL: srv.URL}}, logger.Init(logger.Config{}))
+	err := tr.PushWebhook(context.Background(), []byte("payload"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}

--- a/translator/translator.go
+++ b/translator/translator.go
@@ -43,7 +43,9 @@ func Init(conf Config, log logger.Interface) Interface {
 	if err != nil {
 		log.Fatal(context.Background(), err)
 	}
-	t.Import(ut.FormatJSON, fmt.Sprintf("%s/%s", pwd, conf.TranslationDir))
+	if err := t.Import(ut.FormatJSON, fmt.Sprintf("%s/%s", pwd, conf.TranslationDir)); err != nil {
+		log.Fatal(context.Background(), err)
+	}
 	if err := t.VerifyTranslations(); err != nil {
 		log.Fatal(context.Background(), err)
 	}


### PR DESCRIPTION
# Changelog

v1.0.1 patch release — bug fixes, security hardening, documentation alignment, and CI hardening. No public API breaks.

  Section 1 — Logic bugs
  
  - auth: RegisterUser / UpdateUser now forward IsDisabled.Bool (was forwarding IsEmailVerified.Bool into Firebase Disabled()).
  - sql: swap reversed MockDB routing so Leader() returns the leader mock and Follower() returns the follower mock.
  - sql: follower is now enabled whenever the follower address (host:port) differs from the leader and follower host is non-empty (was incorrectly
  disabled when both host and port differed).
  - storage: replace manual Download read loop with io.ReadAll, guard nil ContentLength, and propagate non-EOF read errors instead of silently
  truncating.
  - files: IsExist no longer dereferences a nil FileInfo on permission-denied / other stat errors.
  - audit: drop sync.Once so successive Init calls return fresh zerolog.Logger instances instead of a zero-value logger.
  - messaging: BatchSendDryRun now chunks the input into MaximumTokensPerBatch (500) batches and merges invalid-token results across all chunks.
  - tracker: default URL/Port are applied before building the conn string; PushWebhook defers resp.Body.Close().
  - convert: ToArrInt64(nil) returns CodeInvalidValue instead of panicking from reflect.TypeOf(nil).

  Section 2 — Security

  - auth/auth_http: defer resp.Body.Close() on the refresh-token exchange and stop logging the request payload / response body; only the HTTP status
  code is logged.
  - security: CompareHashPassword uses subtle.ConstantTimeCompare to remove the timing side-channel.
  - nosql: redact embedded passwords from the DSN before logging on fatal/info paths.
  - gqlclient: redact Authorization, Cookie, and X-API-Key headers from debug logs; truncate variables and response bodies to 512 bytes.

  Section 3 — API consistency / Go idioms

  - messaging.Init: rename the unused httpClient parameter to _ and mark it Deprecated: (will be removed in v2.0.0). Signature preserved — callers
  compile unchanged.
  - checker: hoist phoneRegex and emailRegex to package-level *regexp.Regexp vars (regexp.MustCompile no longer runs on every call).
  - query: hoist the sort-clause regex out of sqlClausebuilder.sort() to a package-level var.

  Section 4 — Documentation

  - READMEs realigned with current code for auth, messaging, storage, sql, query.
  - Package-level GoDoc added to auth, storage, messaging, sql, query, scheduler, tracker, audit, localstorage, appcontext, clock, convert, dates,
  checker, files, stringlib, num.
  - GoDoc added on key exported symbols (Interface, Config, Init, ConnConfig, AWSS3Config, JobOption, etc.).

  Section 5 — CI / tooling

  - .github/workflows/go.yml: add a go mod tidy diff check after the gofmt step.
  - .github/workflows/release.yml: gate the existing release job on a new validate job that runs make build and make run-tests.
  - .golangci.yml: re-enable bodyclose and errcheck; fix the warnings they surface (configreader, gqlclient, logger, translator, storage tests).
  - Makefile: drop -failfast from the test targets so all packages run even when one fails.
  - go mod tidy refresh of go.mod / go.sum.

  Validation

  - go build ./... — clean.
  - go test ./... — all packages pass.
  - gofmt -s -l . — no output.
  - go mod tidy — no diff.
  - golangci-lint run — 0 issues.

## The changes contain

- [ ] new features
- [ ] bugfix
- [ ] code improvements
- [ ] breaking changes
